### PR TITLE
Feature: initiate machine.Pin if Int, otherwise return as passed.

### DIFF
--- a/mp_button/mp_button.py
+++ b/mp_button/mp_button.py
@@ -26,7 +26,11 @@ class Button(object):
       self.rest_state = True
     else:
       self.internal_pull = None
-    self.pin = Pin(pin, mode = Pin.IN, pull = self.internal_pull)
+    if isinstance(pin, int):
+      self.pin = Pin(pin, mode = Pin.IN, pull = self.internal_pull)
+    else:
+      self.pin = pin
+      
     self.callback = callback
     self.active = False
   


### PR DESCRIPTION
This PR implements the option to pass in an `Int` as Pin number (GPIO nr) or a straight `machine.Pin` compliant object.
When using GPIO expanders' pin instances that can act as Pins this comes in handy